### PR TITLE
Fixed resource-leak bug; implemented timeouts for async calls (1812:160)

### DIFF
--- a/perl-GRNOC-RabbitMQ.spec
+++ b/perl-GRNOC-RabbitMQ.spec
@@ -16,6 +16,7 @@ Requires: perl-AnyEvent-RabbitMQ
 Requires: perl-JSON-XS
 Requires: perl-JSON-Schema
 Requires: perl-autovivification
+Requires: perl(Data::Dumper)
 
 %description
 The GRNOC::RabbitMQ collection is a set of perl modules which are used to


### PR DESCRIPTION
When timeouts occurred for synchronous calls, we didn't remove the correlation
entry from the pending responses hash; this has been fixed. We didn't support
timeouts at all for asynchronous calls; this has been added.

I also made Client.pm (and the package) explicitly depend on Data::Dumper,
as it is being used, but we don't make sure it's available to our module.
