### PR TITLE
Some documentation improvements

### DIFF
--- a/lib/GRNOC/RabbitMQ/Client.pm
+++ b/lib/GRNOC/RabbitMQ/Client.pm
@@ -46,7 +46,7 @@ use Data::Dumper;
 
 sub main{
 
-    my $client = GRNOC::RabbitMQ::Client->new(topi => "OF.FWDCTL",
+    my $client = GRNOC::RabbitMQ::Client->new(topic => "OF.FWDCTL",
                                               exchange => 'OESS',
                                               user => 'guest',
                                               pass => 'guest');

--- a/lib/GRNOC/RabbitMQ/Client.pm
+++ b/lib/GRNOC/RabbitMQ/Client.pm
@@ -42,6 +42,7 @@ use strict;
 use warnings;
 
 use GRNOC::RabbitMQ::Client;
+use AnyEvent;
 use Data::Dumper;
 
 sub main{
@@ -51,9 +52,20 @@ sub main{
                                               user => 'guest',
                                               pass => 'guest');
 
-    my $res = $client->do_stuff();
+    # synchronous call
+    my $res = $client->plus(a => 2, b => 2);
     warn Data::Dumper::Dumper($res);
 
+    # asynchronous call
+    my $cv = AnyEvent->condvar;
+    $client->plus(a => 2,
+                  b => 2,
+                  async_callback => sub {
+                      my $res = shift;
+                      warn Data::Dumper::Dumper($res);
+                      $cv->send;
+                  });
+    $cv->recv;
 }
 
 main();

--- a/lib/GRNOC/RabbitMQ/Dispatcher.pm
+++ b/lib/GRNOC/RabbitMQ/Dispatcher.pm
@@ -37,27 +37,36 @@ use GRNOC::RabbitMQ::Method;
 sub main{
 
     my $dispatcher = GRNOC::RabbitMQ::Dispatcher->new(queue => "OF-FWDCTL",
-						      topic => "OF.FWDCTL",
+                                                      topic => "OF.FWDCTL",
                                                       exchange => 'OESS',
                                                       user => 'guest',
                                                       pass => 'guest');
 
-    my $method = GRNOC::RabbitMQ::Method->new( name => "do_stuff",
-                                               callback => \&do_stuff,
-                                               description => "Does stuff" );
-    $method->set_schema_validator( schema => {});
+    my $method = GRNOC::RabbitMQ::Method->new( name => "plus",
+                                               callback => \&do_plus,
+                                               description => "Add numbers a and b together" );
+    $method->set_schema_validator( schema => {} );
+
+    $method->add_input_parameter( name => 'a',
+                                  description => 'first addend',
+                                  pattern => '^(-?[0-9]+)$' );
+
+    $method->add_input_parameter( name => 'b',
+                                  description => 'second addend',
+                                  pattern => '^(-?[0-9]+)$' );
 
     $dispatcher->register_method( $method );
 
     $dispatcher->start_consuming();
 }
 
-sub do_stuff{
-    my $json = shift;
+sub do_plus{
+    my ($method_obj,$params,$state) = @_;
 
-    warn "\o/ it just works\n";
+    my $a = $params->{'a'}{'value'};
+    my $b = $params->{'b'}{'value'};
 
-    return {success => 1};
+    return { result => ($a+$b) };
 }
 
 main();


### PR DESCRIPTION
The examples in the documentation didn't show how to pass and consume parameters, and didn't show an example of an asynchronous call in GRNOC::RabbitMQ::Client. I've added that stuff in.
