### PR TITLE
Fix dependency-omission bug

### DIFF
--- a/lib/GRNOC/RabbitMQ/Method.pm
+++ b/lib/GRNOC/RabbitMQ/Method.pm
@@ -18,6 +18,7 @@ use AnyEvent;
 use GRNOC::Log;
 use JSON::XS;
 use JSON::Schema;
+use GRNOC::WebService::Regex;
 
 =head1 NAME
 

--- a/perl-GRNOC-RabbitMQ.spec
+++ b/perl-GRNOC-RabbitMQ.spec
@@ -16,6 +16,7 @@ Requires: perl-AnyEvent-RabbitMQ
 Requires: perl-JSON-XS
 Requires: perl-JSON-Schema
 Requires: perl-autovivification
+Requires: perl(GRNOC::WebService::Regex)
 
 %description
 The GRNOC::RabbitMQ collection is a set of perl modules which are used to


### PR DESCRIPTION
GRNOC::RabbitMQ::Method depends on GRNOC::WebService::Regex, but the module didn't explicitly include the module, nor was this dependency reflected in the specfile for the package. The second omission led to the module bombing out when I tried using it on a machine without GRNOC::WebService::Regex already installed on it; the first caused bad things to happen even when GRNOC::WebService::Regex was available on the system. This pull request contains fixes to both problems.
