### PR TITLE
Adding sync to prevent Dispatcher crash.

### DIFF
--- a/lib/GRNOC/RabbitMQ/Dispatcher.pm
+++ b/lib/GRNOC/RabbitMQ/Dispatcher.pm
@@ -435,7 +435,6 @@ sub register_method{
                                 exchange => $self->exchange,
                                 routing_key => $method_ref->get_name(),
                                 on_success => sub {
-                                    $self->logger->info("Calling on_success for bind_queue");
                                     $cv->send();
                                 } );
 


### PR DESCRIPTION
Theory:
Normally consume is called and its response is received before the bind request
goes on the wire. If however, a bind request hits the wire prior to consumeok
being received, the message queue inside AnyEvent::RabbitMQ may serve consumeok
to the queueok callback resulting in an error. I *think* messages on the wire
are assumed in-order in this case. Adding some synchronization to keep messages
in order seems to have fixed the issue.