### PR TITLE
The AnyEvent timer can fall behind if callbacks take a long time

### DIFF
--- a/lib/GRNOC/RabbitMQ/Client.pm
+++ b/lib/GRNOC/RabbitMQ/Client.pm
@@ -261,6 +261,9 @@ sub on_response_cb {
             }
 
             &$cb(decode_json($body));
+            #if the callback takes a long time to update the timers may get screwed up
+            #we update the now_update to update it
+            AnyEvent->now_update;
         } else {
             $self->logger->debug("I don't know what to do with corr_id: $corr_id");
         }

--- a/lib/GRNOC/RabbitMQ/Dispatcher.pm
+++ b/lib/GRNOC/RabbitMQ/Dispatcher.pm
@@ -348,7 +348,9 @@ sub handle_request{
                                                $var->{'body'}->{'payload'},
                                                $self->{'default_input_validators'},
                                                $state);
-
+    #if it took a long time to call the method it is possible the anyevent
+    #timer is now screwed up this will refresh it
+    AnyEvent->now_update;
     return 1;
 }
 

--- a/perl-GRNOC-RabbitMQ.spec
+++ b/perl-GRNOC-RabbitMQ.spec
@@ -1,6 +1,6 @@
 Summary: GRNOC RabbitMQ Perl Libraries
 Name: perl-GRNOC-RabbitMQ
-Version: 1.1.0
+Version: 1.1.1
 Release: 1%{?dist}
 License: APL 2.0
 Group: Network


### PR DESCRIPTION
The AnyEvent timer can fall behind if callbacks take a long time to finish executing or does a lot of work

to prevent this we can use AnyEvent->now_update to refresh the timer and not modify code elsewhere