### PR TITLE
Moving validation error messages to the response's `error` key

### DIFF
--- a/lib/GRNOC/RabbitMQ/Method.pm
+++ b/lib/GRNOC/RabbitMQ/Method.pm
@@ -535,17 +535,14 @@ sub _return_error{
     my %error;
 
     if (!defined $results) {
-        # Left in for legacy purposes, although I'm not sure this was
-        # ever actually used.
-        $error{"error"}      = 1;
-        $error{'error_text'} = $self->get_error();
+        $error{"error"} = $self->get_error();
     } else {
         $error{"error"} = $results;
     }
-    
+
     if (!defined($reply_to->{'routing_key'})) {
-	$rabbit_mq_channel->ack();
-	return;
+        $rabbit_mq_channel->ack();
+        return;
     }
 
     my $json;

--- a/t/05-param-validation.t
+++ b/t/05-param-validation.t
@@ -68,8 +68,8 @@ $client->plus( a => 5,
 
 $dispatcher->start_consuming();
 
-ok(defined($res->{'error'}) && $res->{'error'} == 1, "Error was defined");
-ok($res->{'error_text'} eq 'Test.Data.plus: CGI input parameter b does not match pattern /^(-?[0-9]+)$/ ', "Proper error text was returned");
+ok(defined($res->{'error'}), "Error was defined");
+ok($res->{'error'} eq 'Test.Data.plus: CGI input parameter b does not match pattern /^(-?[0-9]+)$/ ', "Proper error text was returned");
 
 
 $client->plus( a => 5,
@@ -82,8 +82,8 @@ $client->plus( a => 5,
 
 $dispatcher->start_consuming();
 
-ok(defined($res->{'error'}) && $res->{'error'} == 1, "Error was defined");
-ok($res->{'error_text'} eq 'JSON did not validate against the specified Schema because: $ The property c is not defined in the schema and the schema does not allow additional properties', "Proper error text was retuned");
+ok(defined($res->{'error'}), "Error was defined");
+ok($res->{'error'} eq 'JSON did not validate against the specified Schema because: $ The property c is not defined in the schema and the schema does not allow additional properties', "Proper error text was retuned");
 
 $client->plus( a => 5,
                async_callback => sub {
@@ -93,5 +93,5 @@ $client->plus( a => 5,
 
 $dispatcher->start_consuming();
 
-ok(defined($res->{'error'}) && $res->{'error'} == 1, "Error was defined");
-ok($res->{'error_text'} eq 'JSON did not validate against the specified Schema because: $.b is missing and it is required', "Proper error text was returned");
+ok(defined($res->{'error'}), "Error was defined");
+ok($res->{'error'} eq 'JSON did not validate against the specified Schema because: $.b is missing and it is required', "Proper error text was returned");

--- a/t/06-schema-validation.t
+++ b/t/06-schema-validation.t
@@ -68,8 +68,8 @@ $client->plus( a => 5,
 
 $dispatcher->start_consuming();
 
-ok(defined($res->{'error'}) && $res->{'error'} == 1, "Error was defined");
-ok($res->{'error_text'} eq 'JSON did not validate against the specified Schema because: $.b string value found, but a number is required', "Proper error text was returned");
+ok(defined($res->{'error'}), "Error was defined");
+ok($res->{'error'} eq 'JSON did not validate against the specified Schema because: $.b string value found, but a number is required', "Proper error text was returned");
 
 
 $client->plus( a => 5,
@@ -93,8 +93,8 @@ $client->plus( a => 5,
 
 $dispatcher->start_consuming();
 
-ok(defined($res->{'error'}) && $res->{'error'} == 1, "Error was defined");
-ok($res->{'error_text'} eq 'JSON did not validate against the specified Schema because: $.b is missing and it is required', "Proper error text was returned");
+ok(defined($res->{'error'}), "Error was defined");
+ok($res->{'error'} eq 'JSON did not validate against the specified Schema because: $.b is missing and it is required', "Proper error text was returned");
 
 $method->set_schema_validator( schema => { type => 'object',
                                            additionalProperties => 0,
@@ -111,5 +111,5 @@ $client->plus( a => 5,
 
 $dispatcher->start_consuming();
 
-ok(defined($res->{'error'}) && $res->{'error'} == 1, "Error was defined");
-ok($res->{'error_text'} eq 'JSON did not validate against the specified Schema because: $ The property c is not defined in the schema and the schema does not allow additional properties', "failes when we specify the additional properties");
+ok(defined($res->{'error'}), "Error was defined");
+ok($res->{'error'} eq 'JSON did not validate against the specified Schema because: $ The property c is not defined in the schema and the schema does not allow additional properties', "failes when we specify the additional properties");

--- a/t/08-patterns.t
+++ b/t/08-patterns.t
@@ -69,8 +69,8 @@ $client->plus( a => 5,
 
 $dispatcher->start_consuming();
 
-ok(defined($res->{'error'}) && $res->{'error'} == 1, "Error was defined");
-ok($res->{'error_text'} eq 'Test.Data.plus: CGI input parameter b does not match pattern /^(-?[0-9]+)$/ ', "Proper error text was returned");
+ok(defined($res->{'error'}), "Error was defined");
+ok($res->{'error'} eq 'Test.Data.plus: CGI input parameter b does not match pattern /^(-?[0-9]+)$/ ', "Proper error text was returned");
 
 
 $client->plus( a => 5,
@@ -83,8 +83,8 @@ $client->plus( a => 5,
 
 $dispatcher->start_consuming();
 
-ok(defined($res->{'error'}) && $res->{'error'} == 1, "Error was defined");
-ok($res->{'error_text'} eq 'JSON did not validate against the specified Schema because: $ The property c is not defined in the schema and the schema does not allow additional properties', "Proper error text was retuned");
+ok(defined($res->{'error'}), "Error was defined");
+ok($res->{'error'} eq 'JSON did not validate against the specified Schema because: $ The property c is not defined in the schema and the schema does not allow additional properties', "Proper error text was retuned");
 
 $client->plus( a => 5,
                async_callback => sub {
@@ -94,8 +94,8 @@ $client->plus( a => 5,
 
 $dispatcher->start_consuming();
 
-ok(defined($res->{'error'}) && $res->{'error'} == 1, "Error was defined");
-ok($res->{'error_text'} eq 'JSON did not validate against the specified Schema because: $.b is missing and it is required', "Proper error text was returned");
+ok(defined($res->{'error'}), "Error was defined");
+ok($res->{'error'} eq 'JSON did not validate against the specified Schema because: $.b is missing and it is required', "Proper error text was returned");
 
 $method = GRNOC::RabbitMQ::Method->new( name => "test",
                                         description => "foo",
@@ -215,7 +215,7 @@ $client->regexp_tests( bool => 2,
 $dispatcher->start_consuming();
 
 ok($res->{'error'}, "expected an error with invalid bool");
-ok($res->{'error_text'} eq 'Test.Data.regexp_tests: Parameter bool only accepts either 0 or 1 for false or true values, respectively.', "Proper error text");
+ok($res->{'error'} eq 'Test.Data.regexp_tests: Parameter bool only accepts either 0 or 1 for false or true values, respectively.', "Proper error text");
 
 $client->regexp_tests( float => 'foo',
                                   async_callback => sub { $res = shift;
@@ -225,7 +225,7 @@ $client->regexp_tests( float => 'foo',
 $dispatcher->start_consuming();
 
 ok($res->{'error'}, "expected an error with invalid float");
-ok($res->{'error_text'} eq 'Test.Data.regexp_tests: Parameter float only accepts floating point numbers.', "Proper error text");
+ok($res->{'error'} eq 'Test.Data.regexp_tests: Parameter float only accepts floating point numbers.', "Proper error text");
 
 $client->regexp_tests( int => 1.02,
                                   async_callback => sub { $res = shift;
@@ -235,7 +235,7 @@ $client->regexp_tests( int => 1.02,
 $dispatcher->start_consuming();
 
 ok($res->{'error'}, "expected an error with invalid int");
-ok($res->{'error_text'} eq 'Test.Data.regexp_tests: Parameter int only accepts integer numbers.', "Proper error text");
+ok($res->{'error'} eq 'Test.Data.regexp_tests: Parameter int only accepts integer numbers.', "Proper error text");
 
 $client->regexp_tests( num => 'asdf',
                                   async_callback => sub { $res = shift;
@@ -245,7 +245,7 @@ $client->regexp_tests( num => 'asdf',
 $dispatcher->start_consuming();
 
 ok($res->{'error'}, "expected an error with invalid number");
-ok($res->{'error_text'} eq "Test.Data.regexp_tests: Parameter num only accepts numbers.");
+ok($res->{'error'} eq "Test.Data.regexp_tests: Parameter num only accepts numbers.");
 
 $client->regexp_tests( name => "asdf" . 0x95,
                                   async_callback => sub { $res = shift;


### PR DESCRIPTION
The async method `error_callback` returns a single key `error` in the
response, but parameter validation errors were contained under the
`error_text` key. These parameter validation error messages have been
moved under the `error` key for consistency.